### PR TITLE
Use reduction to avoid dereferencing a null value

### DIFF
--- a/sts.js
+++ b/sts.js
@@ -17,14 +17,17 @@ module.exports = {
                      SAMLAssertion,
                    };
 
-    // Get the alias of the account if it exists. Otherwise, use the #.
+    // Get the alias of the account if it exists.
+    // Otherwise, use the account number.
+    // TODO: It may make sense to extract this into a function.
     const roleAccount = (
                           config.AccountAliases
                           && config.AccountAliases
                                    .filter(
                                      x => x.AccountNumber
                                      === accountNumber,
-                                   )[0].Alias
+                                   )
+                                   .reduce((acc, alias) => alias.Alias, null)
                         )
                         || accountNumber;
 

--- a/test/assumeRole.spec.js
+++ b/test/assumeRole.spec.js
@@ -3,14 +3,19 @@
 const expect     = require('unexpected');
 const sts        = require('../sts.js');
 
-const MOCK_ACCOUNT_ALIAS        = 'Lab';
-const MOCK_ROLE_ATTRIBUTE_VALUE = 'arn:aws:iam::012345678910:role/MockRole,arn:aws:iam::012345678910:saml-provider/providername';
-const MOCK_SAML_ASSERTION       = '';
-const MOCK_CREDENTIALS          = {
-                                    accessKeyId:  '',
-                                    secretKey:    '',
-                                    SessionToken: '',
-                                  };
+const MOCK_SAML_ASSERTION = '';
+const MOCK_CREDENTIALS    = {
+                              accessKeyId:  '',
+                              secretKey:    '',
+                              SessionToken: '',
+                            };
+
+const MOCK_ACCOUNT_NUMBER = {
+                              lab:  '012345678910',
+                              sbx:  '123456789101',
+                              dev:  '234567891012',
+                              prod: '345678910123',
+                            };
 
 const MOCK_STS = {
   /* eslint-disable no-unused-vars */
@@ -24,44 +29,195 @@ const MOCK_STS = {
 describe(
   '#assumeRole(config, logger, STS, roleAttributeValue, SAMLAssertion)',
   () => {
-    describe('With Alias', () => {
-      const MOCK_CONFIG = {
-                            AccountAliases: [
-                              {
-                                AccountNumber: '012345678910',
-                                Alias:         MOCK_ACCOUNT_ALIAS,
-                              },
-                            ],
-                          };
+    describe('With a Single Alias Configured...', () => {
+      describe('When the role matches the alias...', () => {
+        const MOCK_ROLE_ATTRIBUTE_VALUE = `arn:aws:iam::${MOCK_ACCOUNT_NUMBER.lab}:role/MockRole,arn:aws:iam::${MOCK_ACCOUNT_NUMBER.lab}:saml-provider/providername`;
+        const MOCK_CONFIG = {
+                              AccountAliases: [
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.lab,
+                                  Alias:         'Lab',
+                                },
+                              ],
+                            };
 
-      const log = [];
+        const log = [];
 
-      /* eslint-disable no-console */
-      const MOCK_LOGGER = {
-                            info: (message) => {
-                                    log.push(message);
-                                  },
-                          };
+        /* eslint-disable no-console */
+        const MOCK_LOGGER = {
+                              info: (message) => {
+                                      log.push(message);
+                                    },
+                            };
 
-      it('Returns an Assumed Role Object', async () => {
-        const actual = await sts.assumeRole(
-          MOCK_CONFIG,
-          MOCK_LOGGER,
-          MOCK_STS,
-          MOCK_ROLE_ATTRIBUTE_VALUE,
-          MOCK_SAML_ASSERTION,
-        );
+        it('Returns an Assumed Role Object', async () => {
+          const actual = await sts.assumeRole(
+            MOCK_CONFIG,
+            MOCK_LOGGER,
+            MOCK_STS,
+            MOCK_ROLE_ATTRIBUTE_VALUE,
+            MOCK_SAML_ASSERTION,
+          );
 
-        expect(actual, 'to equal', {
-                                     accountNumber: '012345678910',
-                                     roleName:      'MockRole',
-                                     credentials:   MOCK_CREDENTIALS,
-                                   });
+          expect(actual, 'to equal', {
+                                       accountNumber: MOCK_ACCOUNT_NUMBER.lab,
+                                       roleName:      'MockRole',
+                                       credentials:   MOCK_CREDENTIALS,
+                                     });
+        });
+
+        it('Logs the correct account name', async () => {
+          expect(log[0], 'to be ok');
+          expect(log[0], 'to contain', 'Lab');
+          expect(log[1], 'to contain', 'Lab');
+        });
       });
 
-      it('Logs the correct account name', async () => {
-        expect(log[0], 'to contain', MOCK_ACCOUNT_ALIAS);
-        expect(log[1], 'to contain', MOCK_ACCOUNT_ALIAS);
+      describe('When the role does not match the alias...', () => {
+        const MOCK_ROLE_ATTRIBUTE_VALUE = `arn:aws:iam::${MOCK_ACCOUNT_NUMBER.sbx}:role/MockRole,arn:aws:iam::${MOCK_ACCOUNT_NUMBER.sbx}:saml-provider/providername`;
+        const MOCK_CONFIG = {
+                              AccountAliases: [
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.lab,
+                                  Alias:         'Lab',
+                                },
+                              ],
+                            };
+
+        const log = [];
+
+        /* eslint-disable no-console */
+        const MOCK_LOGGER = {
+                              info: (message) => {
+                                      log.push(message);
+                                    },
+                            };
+
+        it('Returns an Assumed Role Object', async () => {
+          const actual = await sts.assumeRole(
+            MOCK_CONFIG,
+            MOCK_LOGGER,
+            MOCK_STS,
+            MOCK_ROLE_ATTRIBUTE_VALUE,
+            MOCK_SAML_ASSERTION,
+          );
+
+          expect(actual, 'to equal', {
+                                       accountNumber: MOCK_ACCOUNT_NUMBER.sbx,
+                                       roleName:      'MockRole',
+                                       credentials:   MOCK_CREDENTIALS,
+                                     });
+        });
+
+        it('Logs the correct account name', async () => {
+          expect(log[0], 'to be ok');
+          expect(log[0], 'to contain', MOCK_ACCOUNT_NUMBER.sbx);
+          expect(log[1], 'to contain', MOCK_ACCOUNT_NUMBER.sbx);
+        });
+      });
+    });
+
+    describe('With Multiple Aliases Configured...', () => {
+      describe('When the role matches an alias...', () => {
+        const MOCK_ROLE_ATTRIBUTE_VALUE = `arn:aws:iam::${MOCK_ACCOUNT_NUMBER.lab}:role/MockRole,arn:aws:iam::${MOCK_ACCOUNT_NUMBER.lab}:saml-provider/providername`;
+        const MOCK_CONFIG = {
+                              AccountAliases: [
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.lab,
+                                  Alias:         'Lab',
+                                },
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.sbx,
+                                  Alias:         'Sandbox',
+                                },
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.dev,
+                                  Alias:         'Dev',
+                                },
+                              ],
+                            };
+
+        const log = [];
+
+        /* eslint-disable no-console */
+        const MOCK_LOGGER = {
+                              info: (message) => {
+                                      log.push(message);
+                                    },
+                            };
+
+        it('Returns an Assumed Role Object', async () => {
+          const actual = await sts.assumeRole(
+            MOCK_CONFIG,
+            MOCK_LOGGER,
+            MOCK_STS,
+            MOCK_ROLE_ATTRIBUTE_VALUE,
+            MOCK_SAML_ASSERTION,
+          );
+
+          expect(actual, 'to equal', {
+                                       accountNumber: MOCK_ACCOUNT_NUMBER.lab,
+                                       roleName:      'MockRole',
+                                       credentials:   MOCK_CREDENTIALS,
+                                     });
+        });
+
+        it('Logs the correct account name', async () => {
+          expect(log[0], 'to be ok');
+          expect(log[0], 'to contain', 'Lab');
+          expect(log[1], 'to contain', 'Lab');
+        });
+      });
+
+      describe('When the role does not match any aliases...', () => {
+        const MOCK_ROLE_ATTRIBUTE_VALUE = `arn:aws:iam::${MOCK_ACCOUNT_NUMBER.prod}:role/MockRole,arn:aws:iam::${MOCK_ACCOUNT_NUMBER.prod}:saml-provider/providername`;
+        const MOCK_CONFIG = {
+                              AccountAliases: [
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.lab,
+                                  Alias:         'Lab',
+                                },
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.sbx,
+                                  Alias:         'Sandbox',
+                                },
+                                {
+                                  AccountNumber: MOCK_ACCOUNT_NUMBER.dev,
+                                  Alias:         'Dev',
+                                },
+                              ],
+                            };
+
+        const log = [];
+
+        /* eslint-disable no-console */
+        const MOCK_LOGGER = {
+                              info: (message) => {
+                                      log.push(message);
+                                    },
+                            };
+
+        it('Returns an Assumed Role Object', async () => {
+          const actual = await sts.assumeRole(
+            MOCK_CONFIG,
+            MOCK_LOGGER,
+            MOCK_STS,
+            MOCK_ROLE_ATTRIBUTE_VALUE,
+            MOCK_SAML_ASSERTION,
+          );
+
+          expect(actual, 'to equal', {
+                                       accountNumber: MOCK_ACCOUNT_NUMBER.prod,
+                                       roleName:      'MockRole',
+                                       credentials:   MOCK_CREDENTIALS,
+                                     });
+        });
+
+        it('Logs the correct account name', async () => {
+          expect(log[0], 'to be ok');
+          expect(log[0], 'to contain', MOCK_ACCOUNT_NUMBER.prod);
+          expect(log[1], 'to contain', MOCK_ACCOUNT_NUMBER.prod);
+        });
       });
     });
   },


### PR DESCRIPTION
Fixes #21 